### PR TITLE
Fix gtest version to 1.12.1 (last to support C++11)

### DIFF
--- a/gdip/CMakeLists.txt.in
+++ b/gdip/CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           release-1.12.1
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
This PR solves to issues. First, Google decided that renaming branch from `master` to `main` is crucial. Secondly, it fixes the version to 1.12.1 because this is the last to support C++11.